### PR TITLE
Fix character escaping in uap3-visualelements

### DIFF
--- a/winrt-related-src/schemas/appxpackage/uapmanifestschema/element-uap3-visualelements-manual.md
+++ b/winrt-related-src/schemas/appxpackage/uapmanifestschema/element-uap3-visualelements-manual.md
@@ -68,9 +68,9 @@ Describes the visual aspects of the app: its default tile, logo images, text and
 
   <!-- Child elements -->
   ( uap:DefaultTile?
-  &amp; uap:LockScreen?
-  &amp; uap:SplashScreen?
-  &amp; uap:InitialRotationPreference?
+  & uap:LockScreen?
+  & uap:SplashScreen?
+  & uap:InitialRotationPreference?
   )
 
 </uap3:VisualElements>

--- a/winrt-related-src/schemas/appxpackage/uapmanifestschema/element-uap3-visualelements-manual.md
+++ b/winrt-related-src/schemas/appxpackage/uapmanifestschema/element-uap3-visualelements-manual.md
@@ -49,16 +49,16 @@ Describes the visual aspects of the app: its default tile, logo images, text and
                                          Remarks for a list of named colors.
                      Square150x150Logo = A string between 1 and 256 characters 
                                          in length that ends with ".jpg", ".png", 
-                                         or ".jpeg" that can&#39;t contain these 
+                                         or ".jpeg" that can't contain these 
                                          characters: <, >, :, ", |, ?, or *. In 
-                                         this string, the / and \ characters can&#39;t 
+                                         this string, the / and \ characters can't 
                                          be the first or last characters. Also, the 
                                          string can contain / or \ but not both.
                      Square44x44Logo   = A string between 1 and 256 characters in 
                                          length that ends with ".jpg", ".png", or 
-                                         ".jpeg" that can&#39;t contain these 
+                                         ".jpeg" that can't contain these 
                                          characters: <, >, :, ", |, ?, or *. In this 
-                                         string, the / and \ characters can&#39;t be the 
+                                         string, the / and \ characters can't be the 
                                          first or last characters. Also, the string 
                                          can contain / or \ but not both.
                      AppListEntry?     = "default" | "none" 


### PR DESCRIPTION
This is a Markdown file. No HTML escaping is needed here.