### PR TITLE
Improve example of ShowNameOnTiles/ShowOn elements

### DIFF
--- a/winrt-related-src/schemas/appxpackage/uapmanifestschema/element-uap-shownameontiles.md
+++ b/winrt-related-src/schemas/appxpackage/uapmanifestschema/element-uap-shownameontiles.md
@@ -111,15 +111,15 @@ None.
 
  
 
-## Remarks
+## Examples
 
-This example shows how to use [**ShowNameOnTiles**](https://msdn.microsoft.com/library/windows/apps/dn391685):
+This example shows how to use the [**ShowNameOnTiles**](element-uap-shownameontiles.md) and [**ShowOn**](element-uap-showon.md) elements:
 
-``` syntax
-          <uap:ShowNameOnTiles>
-            <uap:ShowOn Tile="square150x150Logo"/> // Show app name on 150x150 logo
-            <uap:ShowOn Tile="wide310x150Logo"/> // Show app name on 310x150 Logo
-          </uap:ShowNameOnTiles>
+``` XML
+<uap:ShowNameOnTiles>
+    <uap:ShowOn Tile="square150x150Logo"/> <!-- Show app name on the 150x150 tile -->
+    <uap:ShowOn Tile="wide310x150Logo"/> <!-- …and also on the 310x150 tile -->
+</uap:ShowNameOnTiles>
 ```
 
 ## Requirements

--- a/winrt-related-src/schemas/appxpackage/uapmanifestschema/element-uap-showon.md
+++ b/winrt-related-src/schemas/appxpackage/uapmanifestschema/element-uap-showon.md
@@ -122,12 +122,15 @@ None.
 
  
 
-## Remarks
+## Examples
 
-This example shows how to use [**ShowOn**](https://msdn.microsoft.com/library/windows/apps/dn391686):
+This example shows how to use the [**ShowNameOnTiles**](element-uap-shownameontiles.md) and [**ShowOn**](element-uap-showon.md) elements:
 
-``` syntax
-            <uap:ShowOn Tile="wide310x150Logo"/> // Show app name on 310x150 Logo
+``` XML
+<uap:ShowNameOnTiles>
+    <uap:ShowOn Tile="square150x150Logo"/> <!-- Show app name on the 150x150 tile -->
+    <uap:ShowOn Tile="wide310x150Logo"/> <!-- …and also on the 310x150 tile -->
+</uap:ShowNameOnTiles>
 ```
 
 ## Requirements


### PR DESCRIPTION
* Put the examples in an “*Examples*” section, not in “*Remarks*”
This matches how it’s generally done. See e.g. [Identity](https://docs.microsoft.com/uwp/schemas/appxpackage/uapmanifestschema/element-identity), [Properties](https://docs.microsoft.com/uwp/schemas/appxpackage/uapmanifestschema/element-properties).

* Use the same example on `ShowNameOnTiles` and `ShowOn`
The doc for [Capability](https://docs.microsoft.com/uwp/schemas/appxpackage/uapmanifestschema/element-capability) similarly does not just show a leaf `Capability` element, but re-uses the same snippet than the one found in [Capabilities](https://docs.microsoft.com/uwp/schemas/appxpackage/uapmanifestschema/element-capabilities), its parent element. This gives more context.

* Link to the proper documentation pages, not to the old Windows 8.1 ones

* Use no extra indentation

* Use proper XML syntax coloring

* Use proper XML comments (and improve, subjectively, the comments content)