### PR TITLE
Fix formatting on WInUI getting started

### DIFF
--- a/winrt-related-src/toolkits/winui/getting-started.md
+++ b/winrt-related-src/toolkits/winui/getting-started.md
@@ -17,7 +17,7 @@ The toolkit is available as NuGet packages that can be added to any existing or 
 1. Download [Visual Studio 2017](https://developer.microsoft.com/windows/downloads) and ensure you choose the **Universal Windows Platform development** Workload in the Visual Studio installer.
 
     > [!NOTE]
-    Visual Studio 2015 doesn't support the Windows UI Library. 
+    > Visual Studio 2015 doesn't support the Windows UI Library. 
 
 2. Open an existing project, or create a new project using the Blank App template under Visual C# -> Windows -> Universal, or the appropriate template for your language projection.  
     > **Important**:  To use WinUI 2.1, your project’s Min version must be 14393 or higher and the Target version must be 17763 or higher.   


### PR DESCRIPTION
Saw this and it looks like a straightforward fix. I copied the pattern from [other docs](https://github.com/MicrosoftDocs/winrt-related/search?p=8&q=%22%5B%21NOTE%5D%22&unscoped_q=%22%5B%21NOTE%5D%22) but I haven't tested

Affects: https://docs.microsoft.com/en-us/uwp/toolkits/winui/getting-started

Looks like this currently:

![chrome_2019-06-29_10-54-30](https://user-images.githubusercontent.com/29742178/60387766-136c2000-9a5d-11e9-9b39-15515ea8231a.png)