### PR TITLE
Fix wrong namespace for Windows.Foundation.IStringable

### DIFF
--- a/winrt-related-src/midl-3/synthesizing-interfaces.md
+++ b/winrt-related-src/midl-3/synthesizing-interfaces.md
@@ -113,7 +113,7 @@ runtimeclass Area
 In the example below, **Area** has members **Height** and **Width**.
 
 ```idl
-runtimeclass Area : Windows.Foundation.Windows.Foundation.IStringable
+runtimeclass Area : Windows.Foundation.IStringable
 {
     Int32 Height;
     Int32 Width;


### PR DESCRIPTION
replace the faulty namespace `Windows.Foundation.Windows.Foundation` by `Windows.Foundation` for `IStringable` in synthesizing-interfaces