### PR TITLE
Update index.md

### DIFF
--- a/winrt-related-src/toolkits/winui/index.md
+++ b/winrt-related-src/toolkits/winui/index.md
@@ -26,7 +26,7 @@ It maintains down-level compatibility with earlier versions of Windows 10, so yo
 
 * **Updated versions of existing controls**: The library also contains updated versions of existing Windows platform controls that you can use with earlier versions of Windows 10.
 
-* **Support for earlier versions of Windows 10**: Windows UI Library APIs work on earlier versions of Windows 10, so you don't have to include version checks or conditional XAML to suppor' users who might not be running the very latest OS.
+* **Support for earlier versions of Windows 10**: Windows UI Library APIs work on earlier versions of Windows 10, so you don't have to include version checks or conditional XAML to support users who might not be running the very latest OS.
 
 * **Support for XamlDirect**: The Xaml Direct APIs, designed for middleware developers, gives you access to a lower-level Xaml features which provide better CPU and working set performance. XamlDirect enables you to use XamlDirect APIs on earlier versions of Windows 10 without needing to write special code to handle multiple target Windows 10 versions.
 


### PR DESCRIPTION
fixed a typo from "suppor'" to "support" in this sentence:

* **Support for earlier versions of Windows 10**: Windows UI Library APIs work on earlier versions of Windows 10, so you don't have to include version checks or conditional XAML to support users who might not be running the very latest OS.