### PR TITLE
Clarify the difference between make and make_self

### DIFF
--- a/winrt-related-src/cpp-ref-for-winrt/make-self.md
+++ b/winrt-related-src/cpp-ref-for-winrt/make-self.md
@@ -13,7 +13,7 @@ ms.workload: ["cplusplus"]
 
 # winrt::make_self function template (C++/WinRT)
 
-A factory method that returns a [com_ptr](com-ptr.md) to an instance of the implementation type for a runtime class. For an explanation of the implementation type and projected type concepts, see [Consume APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/consume-apis) and [Author APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/author-apis). Also see [make](make.md).
+A factory method that returns a [com_ptr](com-ptr.md) to an instance of the implementation type for a runtime class. For an explanation of the implementation type and projected type concepts, see [Consume APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/consume-apis) and [Author APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/author-apis). Also see [make](make.md), which returns an *instance* of the *projected* type instead.
 
 If you're authoring a runtime class then, from within the same compilation unit, you can use **make_self** to construct an instance of the implementation type for the runtime class. Assign the return value from **make_self** to a [com_ptr](com-ptr.md) of your implementation type so that you manage the lifetime of the object appropriately.
 

--- a/winrt-related-src/cpp-ref-for-winrt/make.md
+++ b/winrt-related-src/cpp-ref-for-winrt/make.md
@@ -21,7 +21,7 @@ A factory method that, when a [C++/WinRT](/windows/uwp/cpp-and-winrt-apis/intro-
 - If you're authoring a component to be consumed from an app, then call **make** to return the default (projected) interface of the implementation type. In this case, your project doesn't contain a projected type.
 - If you're both implementing and consuming a runtime class within the same compilation unit&mdash;for example, authoring a type to be consumed from XAML UI&mdash;then call **make** to return an instance of the projected type.
 
-For an explanation of the implementation type and projected type concepts, see [Consume APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/consume-apis) and [Author APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/author-apis). For more details, code, and a walkthrough of calling **make** in practice, see [XAML; binding a control to C++/WinRT properties and collections](/windows/uwp/cpp-and-winrt-apis/binding-property#add-a-property-of-type-bookstoreviewmodel-to-mainpage). Also see [make_self](make-self.md), which returns an instance of the *implementation* type instead.
+For an explanation of the implementation type and projected type concepts, see [Consume APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/consume-apis) and [Author APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/author-apis). For more details, code, and a walkthrough of calling **make** in practice, see [XAML; binding a control to C++/WinRT properties and collections](/windows/uwp/cpp-and-winrt-apis/binding-property#add-a-property-of-type-bookstoreviewmodel-to-mainpage). Also see [make_self](make-self.md), which returns a [*com_ptr*](com-ptr.md) to an instance of the *implementation* type instead.
 
 ## Syntax
 ```cppwinrt

--- a/winrt-related-src/cpp-ref-for-winrt/make.md
+++ b/winrt-related-src/cpp-ref-for-winrt/make.md
@@ -21,7 +21,7 @@ A factory method that, when a [C++/WinRT](/windows/uwp/cpp-and-winrt-apis/intro-
 - If you're authoring a component to be consumed from an app, then call **make** to return the default (projected) interface of the implementation type. In this case, your project doesn't contain a projected type.
 - If you're both implementing and consuming a runtime class within the same compilation unit&mdash;for example, authoring a type to be consumed from XAML UI&mdash;then call **make** to return an instance of the projected type.
 
-For an explanation of the implementation type and projected type concepts, see [Consume APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/consume-apis) and [Author APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/author-apis). For more details, code, and a walkthrough of calling **make** in practice, see [XAML; binding a control to C++/WinRT properties and collections](/windows/uwp/cpp-and-winrt-apis/binding-property#add-a-property-of-type-bookstoreviewmodel-to-mainpage). Also see [make_self](make-self.md).
+For an explanation of the implementation type and projected type concepts, see [Consume APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/consume-apis) and [Author APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/author-apis). For more details, code, and a walkthrough of calling **make** in practice, see [XAML; binding a control to C++/WinRT properties and collections](/windows/uwp/cpp-and-winrt-apis/binding-property#add-a-property-of-type-bookstoreviewmodel-to-mainpage). Also see [make_self](make-self.md), which returns an instance of the *implementation* type instead.
 
 ## Syntax
 ```cppwinrt


### PR DESCRIPTION
Today, it is hard for new users to understand the difference between `make` and `make_self` (since a lot of the words like "implementation type" and "projection type" are new and overwhelming). This change makes the difference between `make` and `make_self` clear.

## What changed?

* Add explanation to `make`'s "see also" link  that explains how `make_self` differs.
* Do the same on the `make_self` page.

This is my best understanding of the functionality.

Thanks!