### PR TITLE
Correct guid constructor noexcept specifier

### DIFF
--- a/winrt-related-src/cpp-ref-for-winrt/guid.md
+++ b/winrt-related-src/cpp-ref-for-winrt/guid.md
@@ -33,8 +33,8 @@ struct guid
         operator GUID const&() const noexcept;
 #endif
 
-        constexpr explicit guid(std::string_view const value) noexcept;
-        constexpr explicit guid(std::wstring_view const value) noexcept;
+        constexpr explicit guid(std::string_view const value);
+        constexpr explicit guid(std::wstring_view const value);
 };
 
 inline bool operator==(guid const& left, guid const& right) noexcept;


### PR DESCRIPTION
The string parsing `guid` constructors for `std::string_view` and `std::wstring_view` throw `std::invalid_argument` on encountering parse errors.

https://github.com/microsoft/cppwinrt/blob/3393e79d5c405ffee25d468f61f921c6216d21fe/strings/base_types.h#L152-L160