### PR TITLE
Minor correction to LocalService enum value

### DIFF
--- a/winrt-related-src/schemas/appxpackage/uapmanifestschema/element-desktop6-service.md
+++ b/winrt-related-src/schemas/appxpackage/uapmanifestschema/element-desktop6-service.md
@@ -31,7 +31,7 @@ Specifies a service that is installed and registered along with the app. These s
 <desktop6:Service
     Name = 'A string with a value between 1 and 32767 characters in length with a non-whitespace character at its beginning and end.'
     StartupType = 'A string that can be one of the following values: "auto", "manual", "disabled", or "delayedStart".'
-    StartAccount = 'A string that can be one of the following values: "localSystem", "localServices", or "networkService".'
+    StartAccount = 'A string that can be one of the following values: "localSystem", "localService", or "networkService".'
     Arguments = 'An optional string with a value between 1 and 32767 characters in length with a non-whitespace character at its beginning and end.' >
 
     desktop6:Dependencies?


### PR DESCRIPTION
Following the doc and using 'localServices' results in MakeAppx failing to create a package due to an invalid manifest. Enabling verbose output produces the following:

MakeAppx : error: Error info: error C00CE169: App manifest validation error: The app manifest must be valid as per schema: Line 49, Column 12, Reason: 'localServices' violates enumeration constraint of 'localSystem localService networkService'. The attribute 'StartAccount' with value 'localServices' failed to parse.

As such, made a minor update to the doc to correct the value (localServices->localService).