### PR TITLE
Add reference to the raw function GetRuntimeClassName

### DIFF
--- a/winrt-related-src/cpp-ref-for-winrt/get-class-name.md
+++ b/winrt-related-src/cpp-ref-for-winrt/get-class-name.md
@@ -10,7 +10,7 @@ ms.workload: ["cplusplus"]
 
 # winrt::get_class_name function (C++/WinRT)
 
-A helper function that retrieves a string containing the fully-qualified type name of the Windows Runtime class represented by an object of a given projected type. This wraps the raw WinRT function [IInspectable::GetRuntimeClassName](/windows/win32/api/inspectable/nf-inspectable-iinspectable-getruntimeclassname).
+A helper function that retrieves a string containing the fully-qualified type name of the Windows Runtime class represented by an object of a given projected type. This is the same value returned from a call to [IInspectable::GetRuntimeClassName](/windows/win32/api/inspectable/nf-inspectable-iinspectable-getruntimeclassname).
 
 For an explanation of the implementation type and projected type concepts, see [Consume APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/consume-apis) and [Author APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/author-apis).
 

--- a/winrt-related-src/cpp-ref-for-winrt/get-class-name.md
+++ b/winrt-related-src/cpp-ref-for-winrt/get-class-name.md
@@ -10,7 +10,7 @@ ms.workload: ["cplusplus"]
 
 # winrt::get_class_name function (C++/WinRT)
 
-A helper function that retrieves a string containing the fully-qualified type name of the Windows Runtime class represented by an object of a given projected type.
+A helper function that retrieves a string containing the fully-qualified type name of the Windows Runtime class represented by an object of a given projected type. This wraps the raw WinRT function [IInspectable::GetRuntimeClassName](/windows/win32/api/inspectable/nf-inspectable-iinspectable-getruntimeclassname).
 
 For an explanation of the implementation type and projected type concepts, see [Consume APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/consume-apis) and [Author APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/author-apis).
 
@@ -44,3 +44,4 @@ assert(name == L"Windows.Foundation.Uri");
 * [winrt namespace](winrt.md)
 * [Consume APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/consume-apis)
 * [Author APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/author-apis)
+* [IInspectable::GetRuntimeClassName](/windows/win32/api/inspectable/nf-inspectable-iinspectable-getruntimeclassname), the raw WinRT function that this helper wraps


### PR DESCRIPTION
Today, `winrt::get_class_name` does not indicate that it derives from `IInspectable::GetRuntimeClassName`. Since the other helper functions [get_trust_level](https://learn.microsoft.com/en-us/uwp/cpp-ref-for-winrt/get-trust-level) and [get_interfaces](https://learn.microsoft.com/en-us/uwp/cpp-ref-for-winrt/get-interfaces) do this, it makes sense to add a note here.

This change adds a reference to the raw IInspectable function GetRuntimeClassName.