### PR TITLE
Add links between winrt::get_class_name & `::GetRuntimeClassName`

### DIFF
--- a/winrt-related-src/cpp-ref-for-winrt/get-class-name.md
+++ b/winrt-related-src/cpp-ref-for-winrt/get-class-name.md
@@ -12,7 +12,7 @@ ms.workload: ["cplusplus"]
 
 A helper function that retrieves a string containing the fully-qualified type name of the Windows Runtime class represented by an object of a given projected type.
 
-For an explanation of the implementation type and projected type concepts, see [Consume APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/consume-apis) and [Author APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/author-apis).
+This is a free function that retrieves the runtime class name of any arbitrary IInspectable. For the automatically-generated member function that is available on all implementation types, see [GetRuntimeClassName](/uwp/cpp-ref-for-winrt/getruntimeclassname). For an explanation of the implementation type and projected type concepts, see [Consume APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/consume-apis) and [Author APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/author-apis).
 
 ## Syntax
 ```cppwinrt

--- a/winrt-related-src/cpp-ref-for-winrt/get-class-name.md
+++ b/winrt-related-src/cpp-ref-for-winrt/get-class-name.md
@@ -12,7 +12,7 @@ ms.workload: ["cplusplus"]
 
 A helper function that retrieves a string containing the fully-qualified type name of the Windows Runtime class represented by an object of a given projected type.
 
-This is a free function that retrieves the runtime class name of any arbitrary IInspectable. For the automatically-generated member function that is available on just implementation types, see [GetRuntimeClassName](/uwp/cpp-ref-for-winrt/getruntimeclassname). For an explanation of the implementation type and projected type concepts, see [Consume APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/consume-apis) and [Author APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/author-apis).
+This is a free function that retrieves the runtime class name of any arbitrary **IInspectable**. For the automatically-generated member function that's available only on implementation types, see [GetRuntimeClassName](/uwp/cpp-ref-for-winrt/getruntimeclassname). For an explanation of the implementation type and projected type concepts, see [Consume APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/consume-apis) and [Author APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/author-apis).
 
 ## Syntax
 ```cppwinrt

--- a/winrt-related-src/cpp-ref-for-winrt/get-class-name.md
+++ b/winrt-related-src/cpp-ref-for-winrt/get-class-name.md
@@ -12,7 +12,7 @@ ms.workload: ["cplusplus"]
 
 A helper function that retrieves a string containing the fully-qualified type name of the Windows Runtime class represented by an object of a given projected type.
 
-This is a free function that retrieves the runtime class name of any arbitrary IInspectable. For the automatically-generated member function that is available on all implementation types, see [GetRuntimeClassName](/uwp/cpp-ref-for-winrt/getruntimeclassname). For an explanation of the implementation type and projected type concepts, see [Consume APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/consume-apis) and [Author APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/author-apis).
+This is a free function that retrieves the runtime class name of any arbitrary IInspectable. For the automatically-generated member function that is available on just implementation types, see [GetRuntimeClassName](/uwp/cpp-ref-for-winrt/getruntimeclassname). For an explanation of the implementation type and projected type concepts, see [Consume APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/consume-apis) and [Author APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/author-apis).
 
 ## Syntax
 ```cppwinrt

--- a/winrt-related-src/cpp-ref-for-winrt/getruntimeclassname.md
+++ b/winrt-related-src/cpp-ref-for-winrt/getruntimeclassname.md
@@ -19,7 +19,7 @@ A member function (of a generated implementation type) that returns a string con
 
 For an explanation of the implementation type and projected type concepts, see [Consume APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/consume-apis) and [Author APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/author-apis).
 
-This is a member function of generated implementation types. To get the runtime class name of an arbitrary IInspectable, use [winrt::get_class_name](/uwp/cpp-ref-for-winrt/get-class-name). Also see the function both methods are based on, [IInspectable::GetRuntimeClassName](/windows/win32/api/inspectable/nf-inspectable-iinspectable-getruntimeclassname).
+This is a member function of generated implementation types. To retrieve the runtime class name of any arbitrary **IInspectable**, use [winrt::get_class_name](/uwp/cpp-ref-for-winrt/get-class-name). Also see the function that both methods are based on, which is [IInspectable::GetRuntimeClassName](/windows/win32/api/inspectable/nf-inspectable-iinspectable-getruntimeclassname).
 
 ## Syntax
 ```cppwinrt

--- a/winrt-related-src/cpp-ref-for-winrt/getruntimeclassname.md
+++ b/winrt-related-src/cpp-ref-for-winrt/getruntimeclassname.md
@@ -19,7 +19,7 @@ A member function (of a generated implementation type) that returns a string con
 
 For an explanation of the implementation type and projected type concepts, see [Consume APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/consume-apis) and [Author APIs with C++/WinRT](/windows/uwp/cpp-and-winrt-apis/author-apis).
 
-Also see [IInspectable::GetRuntimeClassName](/windows/win32/api/inspectable/nf-inspectable-iinspectable-getruntimeclassname).
+This is a member function of generated implementation types. To get the runtime class name of an arbitrary IInspectable, use [winrt::get_class_name](/uwp/cpp-ref-for-winrt/get-class-name). Also see the function both methods are based on, [IInspectable::GetRuntimeClassName](/windows/win32/api/inspectable/nf-inspectable-iinspectable-getruntimeclassname).
 
 ## Syntax
 ```cppwinrt


### PR DESCRIPTION
Today, the documentation for `GetRuntimeClassName` (a generated function for implementation types) does not mention the generic equivalent, `winrt::get_class_name` (a free function for getting the class name of arbitary `IInspectable`s), and vice versa.

This change adds crosslinks to both.