### PR TITLE
Document try_as behavior on null references

### DIFF
--- a/winrt-related-src/cpp-ref-for-winrt/windows-foundation-iunknown.md
+++ b/winrt-related-src/cpp-ref-for-winrt/windows-foundation-iunknown.md
@@ -115,10 +115,12 @@ The type of the requested interface.
 
 ### Parameters
 `to`
-A reference to a value to receive the requested interface.
+A reference to a value to receive the requested interface. Can be a null reference.
 
 ### Return value 
 A **com_ptr** referencing the requested interface, or a strongly-typed smart pointer for the requested interface (either declared by C++/WinRT or by a third party), if the requested interface is supported, otherwise `null` (the `auto`-returning overload) or `false` (the `bool`-returning overload).
+
+If `to` is a null reference, returns `null` or `false`.
 
 ## IUnknown::operator bool
 Checks whether or not the **IUnknown** object is referencing an interface. If the **IUnknown** object is not referencing an interface, then it is logically null; otherwise it is logically not null.


### PR DESCRIPTION
This confused me & I had to run tests. It's the difference between:

```cpp
if (const auto a = someObj.GenericProperty())
{
    if (const auto b = a.try_as<SomeOtherInterface>())
    {
    }
}
```

and

```
if (const auto a = someObj.GenericProperty().try_as<SomeOtherInterface>())
{
}
```