### PR TITLE
Update element-uap3-properties-manual.md

### DIFF
--- a/winrt-related-src/schemas/appxpackage/uapmanifestschema/element-uap3-properties-manual.md
+++ b/winrt-related-src/schemas/appxpackage/uapmanifestschema/element-uap3-properties-manual.md
@@ -56,7 +56,7 @@ None.
 
 ## Examples
 
-The following example indicates that the app hosts or consumes the low-performance browser extension
+The following example indicates that the app hosts or consumes a high-performance browser extension
 
 ```xml
 <Package ...


### PR DESCRIPTION
- slight wording inconsistency

This change is based off of the example on this page for an example on uap3:AppExtension:
https://learn.microsoft.com/en-us/uwp/schemas/appxpackage/uapmanifestschema/element-uap3-appextension-manual#examples

I am so sorry if this is more of an inconvenience to change such a small thing! I've never created a pull request before.