### PR TITLE
Fix winrt::com_ptr put/put_void to describe implemented behavior

### DIFF
--- a/winrt-related-src/cpp-ref-for-winrt/com-ptr.md
+++ b/winrt-related-src/cpp-ref-for-winrt/com-ptr.md
@@ -244,7 +244,7 @@ T* get() const noexcept;
 A pointer to the interface or object referenced by the **com_ptr** object.
 
 ## com_ptr::put function
-Returns the address of the underlying raw pointer; this function helps you call methods (such as COM methods) that return references as out parameters via a pointer to a pointer. If the **com_ptr** object already has a target, then assign `nullptr` to the **com_ptr** object before calling this function, otherwise the function will assert.
+Returns the address of the underlying raw pointer to be passed to a function that will fill in the value; this function helps you call methods (such as COM methods) that return references as out parameters via a pointer to a pointer.
 
 ### Syntax
 ```cppwinrt
@@ -255,7 +255,7 @@ T** put() noexcept;
 The address of the underlying raw pointer.
 
 ## com_ptr::put_void function
-Returns the address of the underlying raw pointer as a pointer to a pointer to **void**; this function helps you call methods (such as COM methods) that return references as out parameters via a pointer to a pointer to **void**. If the **com_ptr** object already has a target, then assign `nullptr` to the **com_ptr** object before calling this function, otherwise the function will assert.
+Returns the address of the underlying raw pointer as a pointer to a pointer to **void** to pass it to a function (such as COM methods) that return references as out parameters via a pointer to a pointer to **void**.
 
 ### Syntax
 ```cppwinrt


### PR DESCRIPTION
In the initial cppwinrt design these methods did not clear the value as an optimization, backed up with an assert. but since many clients don't build with asserts on, it is very easy for bugs to creep in. 
The design was changed to this safer behavior, exhibited by other com smart pointer implementations.

This makes it safe to use in IEnumXXX scenarios.