### PR TITLE
[single_threaded_*] Document the correct header

### DIFF
--- a/winrt-related-src/cpp-ref-for-winrt/single-threaded-map.md
+++ b/winrt-related-src/cpp-ref-for-winrt/single-threaded-map.md
@@ -55,7 +55,7 @@ An [**IMap**](/uwp/api/windows.foundation.collections.imap_k_v_) representing a 
 
 **Namespace:** winrt
 
-**Header:** %WindowsSdkDir%Include\<WindowsTargetPlatformVersion>\cppwinrt\winrt\base.h (included by default)
+**Header:** %WindowsSdkDir%Include\<WindowsTargetPlatformVersion>\cppwinrt\winrt\Windows.Foundation.Collections.h
 
 ## See also 
 * [winrt namespace](winrt.md)

--- a/winrt-related-src/cpp-ref-for-winrt/single-threaded-observable-map.md
+++ b/winrt-related-src/cpp-ref-for-winrt/single-threaded-observable-map.md
@@ -55,7 +55,7 @@ An [**IObservableMap**](/uwp/api/windows.foundation.collections.iobservablemap_k
 
 **Namespace:** winrt
 
-**Header:** %WindowsSdkDir%Include\<WindowsTargetPlatformVersion>\cppwinrt\winrt\base.h (included by default)
+**Header:** %WindowsSdkDir%Include\<WindowsTargetPlatformVersion>\cppwinrt\winrt\Windows.Foundation.Collections.h
 
 ## See also
 * [winrt namespace](winrt.md)

--- a/winrt-related-src/cpp-ref-for-winrt/single-threaded-observable-vector.md
+++ b/winrt-related-src/cpp-ref-for-winrt/single-threaded-observable-vector.md
@@ -43,7 +43,7 @@ An [**IObservableVector**](/uwp/api/windows.foundation.collections.iobservableve
 
 **Namespace:** winrt
 
-**Header:** %WindowsSdkDir%Include\<WindowsTargetPlatformVersion>\cppwinrt\winrt\base.h (included by default)
+**Header:** %WindowsSdkDir%Include\<WindowsTargetPlatformVersion>\cppwinrt\winrt\Windows.Foundation.Collections.h
 
 ## If you have an older version of the Windows SDK
 

--- a/winrt-related-src/cpp-ref-for-winrt/single-threaded-vector.md
+++ b/winrt-related-src/cpp-ref-for-winrt/single-threaded-vector.md
@@ -43,7 +43,7 @@ An [**IVector**](/uwp/api/windows.foundation.collections.ivector_t_) representin
 
 **Namespace:** winrt
 
-**Header:** %WindowsSdkDir%Include\<WindowsTargetPlatformVersion>\cppwinrt\winrt\base.h (included by default)
+**Header:** %WindowsSdkDir%Include\<WindowsTargetPlatformVersion>\cppwinrt\winrt\Windows.Foundations.Collections.h
 
 ## See also 
 * [winrt namespace](winrt.md)


### PR DESCRIPTION
At least in modern versions of C++/WinRT, `winrt::single_threaded_vector<T>` (etc) are not in `base.h`. They are in `Windows.Foundation.Collections.h`.

This change documents that.