### PR TITLE
Clarify winrt::guid_of documentation

### DIFF
--- a/winrt-related-src/cpp-ref-for-winrt/guid-of.md
+++ b/winrt-related-src/cpp-ref-for-winrt/guid-of.md
@@ -12,7 +12,9 @@ ms.workload: ["cplusplus"]
 
 # winrt::guid_of function template (C++/WinRT)
 
-A helper function template that retrieves the default interface for classes inheriting `winrt::implements`. Will fall back to using `__uuidof` for other classes.
+A helper function template that retrieves the GUID of a runtime class, coclass, or interface; that is, the identifier of the WinRT type. For COM and WinRT interfaces, that's the identifier of the interface. For WinRT classes, it's the identifier of the default interface of the class.
+
+It's only if and when `guid_v` (see the function's implementation) isn't specialized that the function falls back to using `__uuidof`, where applicable.
 
 ## Syntax
 ```cppwinrt

--- a/winrt-related-src/cpp-ref-for-winrt/guid-of.md
+++ b/winrt-related-src/cpp-ref-for-winrt/guid-of.md
@@ -12,7 +12,7 @@ ms.workload: ["cplusplus"]
 
 # winrt::guid_of function template (C++/WinRT)
 
-A helper function template that retrieves the GUID of a runtime class, coclass, or interface.
+A helper function template that retrieves the default interface for classes inheriting `winrt::implements`. Will fall back to using `__uuidof` for other classes.
 
 ## Syntax
 ```cppwinrt


### PR DESCRIPTION
Based on discussion in https://github.com/microsoft/cppwinrt/issues/1494 where @kennykerr stated the following:
> The `guid_of` function returns the identifier of the WinRT type. For COM and WinRT interfaces, this is the identifier of the interface. For WinRT classes, this is required to be the same as that of the default interface of the class.
> It is only if and when `guid_v` is not specialized that it will fallback to using `__uuidof` where applicable.

**DISCLAIMER**: I'm new to WinRT so someone knowledgeable in the area should carefully proof-read my proposal.