### PR TITLE
Add schema documentation for windows.diagnosticServiceModule extension

### DIFF
--- a/winrt-related-src/schemas/appxpackage/uapmanifestschema/element-dsm-diagnosticservicemodule.md
+++ b/winrt-related-src/schemas/appxpackage/uapmanifestschema/element-dsm-diagnosticservicemodule.md
@@ -1,0 +1,91 @@
+---
+title: dsm:DiagnosticServiceModule
+description: Specifies a diagnostic service module file within the package that should be accessible to diagnostic tools.
+keywords: windows 10, uwp, schema, manifest, extension, diagnostic service module, DAC, WER
+ms.date: 07/01/2026
+ms.topic: reference
+no-loc: [dsm:DiagnosticServiceModule]
+---
+
+# dsm:DiagnosticServiceModule
+
+Specifies a diagnostic service module file within the package that should be accessible to diagnostic tools.
+
+## Element hierarchy
+
+**[`<Package>`](element-f-package.md)**  
+&nbsp;&nbsp;&nbsp;└─ [`<Applications>`](element-f-applications.md)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;└─ [`<Application>`](element-f-application.md)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;└─ [`<Extensions>`](element-f-application-extensions.md)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;└─ [`<dsm:Extension>`](element-dsm-extension.md)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;└─ [`<dsm:DiagnosticServiceModules>`](element-dsm-diagnosticservicemodules.md)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;└─ **`<dsm:DiagnosticServiceModule>`**  
+
+## Syntax
+
+```xml
+<dsm:DiagnosticServiceModule
+  File = 'A string with a value between 1 and 256 characters in length that cannot contain these characters: <, >, :, ", |, ?, or *.' />
+```
+
+## Attributes and elements
+
+### Attributes
+
+| Attribute | Description | Data type | Required | Default value |
+|-|-|-|-|-|
+| **File** | The path to the diagnostic service module file, relative to the package install directory. The file must exist within the package. Path traversals that resolve outside the package install directory are rejected. | A string with a value between 1 and 256 characters in length that cannot contain these characters: `<`, `>`, `:`, `"`, `|`, `?`, or `*`. | Yes |  |
+
+### Child elements
+
+None.
+
+### Parent elements
+
+| Parent element | Description |
+|-|-|
+| [dsm:DiagnosticServiceModules](element-dsm-diagnosticservicemodules.md) | Contains one or more diagnostic service module file declarations. |
+
+## Remarks
+
+During package deployment, the system grants `FILE_GENERIC_READ | FILE_GENERIC_EXECUTE` permissions to `BUILTIN\Administrators` on the file specified by the **File** attribute. This enables administrative diagnostic tools (such as Windows Error Reporting) to load the DLL from within the protected `WindowsApps` folder.
+
+The **File** attribute specifies a path relative to the package install root. It may include subdirectory components (for example, `MyApp\mscordaccore.dll`). The resolved canonical path must remain within the package install directory; any path traversal (such as `..`) that would escape the package root causes the registration to fail with `E_INVALIDARG`.
+
+If the file does not exist at the specified path when the package is deployed, registration fails with `HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND)`.
+
+### Security considerations
+
+Only files within the MSIX package boundary can be specified. The Deployment Extension Handler validates that the canonicalized path starts with the package install directory, preventing arbitrary file ACL modifications.
+
+The permissions granted are scoped to `BUILTIN\Administrators` with read and execute access only. This does not grant write access and does not affect non-administrator users.
+
+## Examples
+
+### Basic usage with a single DAC file
+
+```xml
+<dsm:Extension Category="windows.diagnosticServiceModule">
+  <dsm:DiagnosticServiceModules>
+    <dsm:DiagnosticServiceModule File="path\from\package\root\file_to_include.dll" />
+  </dsm:DiagnosticServiceModules>
+</dsm:Extension>
+```
+
+### Multiple diagnostic modules in a subdirectory
+
+```xml
+<dsm:Extension Category="windows.diagnosticServiceModule">
+  <dsm:DiagnosticServiceModules>
+    <dsm:DiagnosticServiceModule File="SubFolder\file_to_include.dll" />
+    <dsm:DiagnosticServiceModule File="SubFolder\another_file.ext" />
+  </dsm:DiagnosticServiceModules>
+</dsm:Extension>
+```
+
+## Requirements
+
+| Item  | Value  |
+|--|--|
+| **Namespace** | `http://schemas.microsoft.com/appx/manifest/diagnosticservicemodule` |
+| **Minimum OS Version** | Windows 10 version 21H2 (Build 22000) |

--- a/winrt-related-src/schemas/appxpackage/uapmanifestschema/element-dsm-diagnosticservicemodules.md
+++ b/winrt-related-src/schemas/appxpackage/uapmanifestschema/element-dsm-diagnosticservicemodules.md
@@ -1,0 +1,70 @@
+---
+title: dsm:DiagnosticServiceModules
+description: Contains one or more diagnostic service module file declarations.
+keywords: windows 10, uwp, schema, manifest, extension, diagnostic service module, DAC
+ms.date: 07/01/2026
+ms.topic: reference
+no-loc: [dsm:DiagnosticServiceModules]
+---
+
+# dsm:DiagnosticServiceModules
+
+Contains one or more diagnostic service module file declarations.
+
+## Element hierarchy
+
+**[`<Package>`](element-f-package.md)**  
+&nbsp;&nbsp;&nbsp;└─ [`<Applications>`](element-f-applications.md)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;└─ [`<Application>`](element-f-application.md)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;└─ [`<Extensions>`](element-f-application-extensions.md)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;└─ [`<dsm:Extension>`](element-dsm-extension.md)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;└─ **`<dsm:DiagnosticServiceModules>`**  
+
+## Syntax
+
+```xml
+<dsm:DiagnosticServiceModules>
+
+  <!-- Child Elements -->
+  dsm:DiagnosticServiceModule{1,unbounded}
+
+</dsm:DiagnosticServiceModules>
+```
+
+## Attributes and elements
+
+### Attributes
+
+None.
+
+### Child elements
+
+| Child element | Description |
+|-|-|
+| [dsm:DiagnosticServiceModule](element-dsm-diagnosticservicemodule.md) | Specifies a diagnostic service module file to register. |
+
+### Parent elements
+
+| Parent element | Description |
+|-|-|
+| [dsm:Extension](element-dsm-extension.md) | Declares the diagnostic service module extensibility point. |
+
+## Remarks
+
+This element must contain at least one [dsm:DiagnosticServiceModule](element-dsm-diagnosticservicemodule.md) child element.
+
+## Examples
+
+```xml
+<dsm:DiagnosticServiceModules>
+  <dsm:DiagnosticServiceModule File="path\from\package\root\file_to_include.dll" />
+  <dsm:DiagnosticServiceModule File="relative\path\to\another_file.ext" />
+</dsm:DiagnosticServiceModules>
+```
+
+## Requirements
+
+| Item  | Value  |
+|--|--|
+| **Namespace** | `http://schemas.microsoft.com/appx/manifest/diagnosticservicemodule` |
+| **Minimum OS Version** | Windows 10 version 21H2 (Build 22000) |

--- a/winrt-related-src/schemas/appxpackage/uapmanifestschema/element-dsm-extension.md
+++ b/winrt-related-src/schemas/appxpackage/uapmanifestschema/element-dsm-extension.md
@@ -1,0 +1,97 @@
+---
+title: dsm:Extension
+description: Declares an extensibility point for the diagnostic service module extension (dsm:Extension).
+keywords: windows 10, uwp, schema, manifest, extension, diagnostic service module, DAC
+ms.date: 07/01/2026
+ms.topic: reference
+no-loc: [Package, Extensions, dsm:Extension]
+---
+
+# dsm:Extension
+
+Declares an extensibility point that registers diagnostic service module files (such as .NET Data Access Component DLLs) for access by diagnostic tools like Windows Error Reporting.
+
+## Element hierarchy
+
+**[`<Package>`](element-f-package.md)**  
+&nbsp;&nbsp;&nbsp;└─ [`<Applications>`](element-f-applications.md)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;└─ [`<Application>`](element-f-application.md)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;└─ [`<Extensions>`](element-f-application-extensions.md)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;└─ **`<dsm:Extension>`**  
+
+## Syntax
+
+```xml
+<dsm:Extension
+  Category = "windows.diagnosticServiceModule" >
+
+  <!-- Child Elements -->
+  dsm:DiagnosticServiceModules
+
+</dsm:Extension>
+```
+
+## Attributes and elements
+
+### Attributes
+
+| Attribute | Description | Data type | Required | Default value |
+|-|-|-|-|-|
+| **Category** | The category of the extension. | Must be the value *windows.diagnosticServiceModule*. | Yes |  |
+
+### Child elements
+
+| Child element | Description |
+|-|-|
+| [dsm:DiagnosticServiceModules](element-dsm-diagnosticservicemodules.md) | Contains one or more diagnostic service module file declarations. |
+
+### Parent elements
+
+| Parent element | Description |
+|-|-|
+| [Extensions (in Application)](element-f-application-extensions.md) | Defines one or more extensibility points for the application. |
+| [Extensions (in Package)](element-extensions.md) | Defines one or more extensibility points for the package. |
+
+## Remarks
+
+The `windows.diagnosticServiceModule` extension registers DLL files within the MSIX package that need to be accessible to diagnostic tools running outside the package container. During package deployment, the system grants `FILE_GENERIC_READ | FILE_GENERIC_EXECUTE` permissions to `BUILTIN\Administrators` on the specified files, enabling diagnostic tools like Windows Error Reporting (WER) to load them.
+
+A common use case is registering the .NET Data Access Component (DAC) DLL (`mscordaccore.dll`) for self-contained .NET applications deployed via MSIX. Without this extension, the DAC files inside the WindowsApps folder are inaccessible to WER, resulting in crash dumps that lack managed debugging information.
+
+The `dsm` namespace should be declared as ignorable in the `<Package>` element so that older OS versions that do not recognize this extension category will skip it without failing package installation.
+
+> [!NOTE]
+> This extension is processed by an undocked Deployment Extension Handler (DEH) that ships with the Windows App SDK. The DEH parses the manifest XML directly, so it works on OS versions that predate built-in knowledge of the `diagnosticservicemodule` namespace.
+
+## Examples
+
+```xml
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:dsm="http://schemas.microsoft.com/appx/manifest/diagnosticservicemodule"
+  IgnorableNamespaces="dsm">
+
+  <!-- ... -->
+
+  <Applications>
+    <Application Id="App" Executable="MyApp.exe" EntryPoint="Windows.FullTrustApplication">
+      <Extensions>
+        <dsm:Extension Category="windows.diagnosticServiceModule">
+          <dsm:DiagnosticServiceModules>
+            <dsm:DiagnosticServiceModule File="path\from\package\root\file_to_include.dll" />
+            <dsm:DiagnosticServiceModule File="relative\path\to\another_file.ext" />
+          </dsm:DiagnosticServiceModules>
+        </dsm:Extension>
+      </Extensions>
+    </Application>
+  </Applications>
+
+</Package>
+```
+
+## Requirements
+
+| Item  | Value  |
+|--|--|
+| **Namespace** | `http://schemas.microsoft.com/appx/manifest/diagnosticservicemodule` |
+| **Minimum OS Version** | Windows 10 version 21H2 (Build 22000) |

--- a/winrt-related-src/toc.yml
+++ b/winrt-related-src/toc.yml
@@ -668,6 +668,12 @@ items:
             href: schemas/appxpackage/uapmanifestschema/element-desktop10-typessupported.md
           - name: desktop10:TypeSupported
             href: schemas/appxpackage/uapmanifestschema/element-desktop10-typesupported.md
+          - name: "dsm:DiagnosticServiceModule"
+            href: schemas/appxpackage/uapmanifestschema/element-dsm-diagnosticservicemodule.md
+          - name: "dsm:DiagnosticServiceModules"
+            href: schemas/appxpackage/uapmanifestschema/element-dsm-diagnosticservicemodules.md
+          - name: "dsm:Extension"
+            href: schemas/appxpackage/uapmanifestschema/element-dsm-extension.md
           - name: "Device"
             href: schemas/appxpackage/uapmanifestschema/element-f-device.md
           - name: "DeviceCapability"


### PR DESCRIPTION
Add reference documentation for the dsm:Extension, dsm:DiagnosticServiceModules, and dsm:DiagnosticServiceModule manifest elements. This extension enables MSIX packages to register diagnostic service module files (such as .NET DAC DLLs) for access by administrative diagnostic tools like Windows Error Reporting.