### PR TITLE
Fix broken schema and reference links

### DIFF
--- a/winrt-related-src/extension-sdks/device-families-overview.md
+++ b/winrt-related-src/extension-sdks/device-families-overview.md
@@ -84,7 +84,7 @@ At build time, these values (together with the value of **TargetDeviceFamily@Nam
 </Dependencies>
 ```
 
-**MaxVersionTested** specifies the maximum version of the device family that your app is targeting that you have tested it against. And **MinVersion** specifies the minimum version of the device family that your app is targeting. For more details, see [**TargetDeviceFamily**](../schemas/appxpackage/uapmanifestschema/element-targetdevicefamily.md).
+**MaxVersionTested** specifies the maximum version of the device family that your app is targeting that you have tested it against. And **MinVersion** specifies the minimum version of the device family that your app is targeting. For more details, see [**TargetDeviceFamily**](../schemas/appxpackage/uapmanifestschema/element-f-targetdevicefamily.md).
 
 > [!IMPORTANT]
 > You should configure these version numbers by means of either your Visual Studio project's property pages, or the values of **WindowsTargetPlatformVersion** and **WindowsTargetPlatformMinVersion** in your project file. Don't edit `AppxManifest.xml`, because the build overwrites that file. And don't edit the **MinVersion** and **MaxVersionTested** attributes of the **TargetDeviceFamily** element in your app package manifest source file (the `Package.appxmanifest` file), because those values are ignored.
@@ -131,7 +131,7 @@ Next, let's look at the topic for the [**StorageFolder.TryGetItemAsync**](/uwp/a
 
 ## How to choose a device family to target
 
-Here are some considerations to help you decide which device family to target. For more details, see [**TargetDeviceFamily**](../schemas/appxpackage/uapmanifestschema/element-targetdevicefamily.md).
+Here are some considerations to help you decide which device family to target. For more details, see [**TargetDeviceFamily**](../schemas/appxpackage/uapmanifestschema/element-f-targetdevicefamily.md).
 
 ### Maximize your app's reach
 
@@ -221,6 +221,6 @@ You don't have to make a decision in advance about every device type that you'll
 ## See also
 
 * [Device family extension SDKs and API contracts](./index.md)
-* [TargetDeviceFamily](../schemas/appxpackage/uapmanifestschema/element-targetdevicefamily.md)
+* [TargetDeviceFamily](../schemas/appxpackage/uapmanifestschema/element-f-targetdevicefamily.md)
 * [What's a Universal Windows Platform (UWP) app](/windows/uwp/get-started/universal-application-platform-guide)
 * [Version-adaptive apps](/windows/uwp/debug-test-perf/version-adaptive-apps)

--- a/winrt-related-src/schemas/appxpackage/appxmanifestschema/element-resource.md
+++ b/winrt-related-src/schemas/appxpackage/appxmanifestschema/element-resource.md
@@ -60,7 +60,7 @@ Declares a language for resources contained in the package.
 <tbody>
 <tr class="odd">
 <td><strong>Language</strong></td>
-<td><p>The language for resources contained in the package. The syntax of this attribute is defined by the IETF's <a href="https://www.rfc-editor.org/rfc/bcp/bcp47.txt">BCP47: Tags for Identifying Languages</a> .</p></td>
+<td><p>The language for resources contained in the package. The syntax of this attribute is defined by the IETF's <a href="https://www.rfc-editor.org/info/bcp47">BCP47: Tags for Identifying Languages</a> .</p></td>
 <td>language</td>
 <td>Yes</td>
 <td></td>

--- a/winrt-related-src/schemas/appxpackage/appxmanifestschema2010-v2/element-resource.md
+++ b/winrt-related-src/schemas/appxpackage/appxmanifestschema2010-v2/element-resource.md
@@ -68,7 +68,7 @@ Declares a language for the resource contained in the package. The scale and Dir
 <tbody>
 <tr class="odd">
 <td><strong>Language</strong></td>
-<td><p>The language for the resource contained in the package. The syntax of this attribute is defined by the IETF's <a href="https://www.rfc-editor.org/rfc/bcp/bcp47.txt">BCP47: Tags for Identifying Languages</a> .</p></td>
+<td><p>The language for the resource contained in the package. The syntax of this attribute is defined by the IETF's <a href="https://www.rfc-editor.org/info/bcp47">BCP47: Tags for Identifying Languages</a> .</p></td>
 <td>language</td>
 <td>No</td>
 <td></td>

--- a/winrt-related-src/schemas/appxpackage/how-to-specify-capabilities-in-a-package-manifest.md
+++ b/winrt-related-src/schemas/appxpackage/how-to-specify-capabilities-in-a-package-manifest.md
@@ -15,7 +15,7 @@ ms.date: 04/05/2017
 # How to specify capabilities in a package manifest
 
 
-**Note**  For Windows 10, see [**uap:Capability**](uapmanifestschema/element-uap-capability.md), [**Capability**](uapmanifestschema/element-capability.md), and [What's different in Windows 10.](uapmanifestschema/what-s-changed-in-windows-10.md)
+**Note**  For Windows 10, see [**uap:Capability**](uapmanifestschema/element-uap-capability.md), [**Capability**](uapmanifestschema/element-f-capability.md), and [What's different in Windows 10.](uapmanifestschema/what-s-changed-in-windows-10.md)
 
  
 

--- a/winrt-related-src/schemas/appxpackage/how-to-specify-device-capabilities-in-a-package-manifest.md
+++ b/winrt-related-src/schemas/appxpackage/how-to-specify-device-capabilities-in-a-package-manifest.md
@@ -20,7 +20,7 @@ ms.date: 04/05/2017
 
  
 
-To declare each device capability required by your Windows Runtime app, add a [**DeviceCapability**](./uapmanifestschema/element-devicecapability.md) element and applicable child elements to the package manifest.
+To declare each device capability required by your Windows Runtime app, add a [**DeviceCapability**](./uapmanifestschema/element-f-devicecapability.md) element and applicable child elements to the package manifest.
 
 > [!IMPORTANT]
 > Some device capabilities must be specified manually. For example, you must use the **XML (Text) Editor** to specify device capabilities for the USB, Human Interface Device (HID), Point of Service (POS), Bluetooth GATT, and Bluetooth RFCOMM APIs.
@@ -35,7 +35,7 @@ Open the Package.appxmanifest file. In Microsoft Visual Studio, open the file wi
 ## Step 2:
 
 
-Add one **DeviceCapability** element per device capability. You can have multiple **DeviceCapability** and **Capability** elements in the **Capabilities** element, but all **DeviceCapability** elements must come after the **Capability** elements. Note that some device capabilities require multiple child elements. For more info, see [**DeviceCapability**](./uapmanifestschema/element-devicecapability.md).
+Add one **DeviceCapability** element per device capability. You can have multiple **DeviceCapability** and **Capability** elements in the **Capabilities** element, but all **DeviceCapability** elements must come after the **Capability** elements. Note that some device capabilities require multiple child elements. For more info, see [**DeviceCapability**](./uapmanifestschema/element-f-devicecapability.md).
 
 > [!NOTE]
 > Not all APIs are available for both UWP apps and Windows 8.x Phone apps. See the API reference documentation for more details about which devices are supported by each API.
@@ -125,7 +125,7 @@ The **bluetooth.rfcomm** device capability enables access to APIs in the [**Wind
 
 [Devices, sensors, and power](/windows/uwp/devices-sensors/)
 
-[**DeviceCapability element reference**](./uapmanifestschema/element-devicecapability.md)
+[**DeviceCapability element reference**](./uapmanifestschema/element-f-devicecapability.md)
 
 [App capability declarations](/windows/uwp/packaging/app-capability-declarations)
 

--- a/winrt-related-src/schemas/appxpackage/uapmanifestschema/element-f-resource.md
+++ b/winrt-related-src/schemas/appxpackage/uapmanifestschema/element-f-resource.md
@@ -40,7 +40,7 @@ See the [BCP-47 language tag](https://go.microsoft.com/fwlink/p/?linkid=227302) 
 
 | Attribute | Description | Data type | Required | Default value |
 |-|-|-|-|-|
-| **Language** | The language for the resource contained in the package. The syntax of this attribute is defined by the IETF's [BCP47: Tags for Identifying Languages](https://www.rfc-editor.org/rfc/bcp/bcp47.txt). | A valid BCP-47 language tag (such as `en`, or `en-us`). | No |  |
+| **Language** | The language for the resource contained in the package. The syntax of this attribute is defined by the IETF's [BCP47: Tags for Identifying Languages](https://www.rfc-editor.org/info/bcp47). | A valid BCP-47 language tag (such as `en`, or `en-us`). | No |  |
 | **uap:Scale** | The [resolution scale](/uwp/api/Windows.Graphics.Display.ResolutionScale) of the resource. | An optional number that can be one of the following values: *80*, *100*, *120*, *125*, *140*, *150*, *160*, *175*, *180*, *200*, *225*, *250*, *300*, *350*, *400*, or *450*. | No |  |
 | **uap:DXFeatureLevel** | The DirectX [feature level](/windows/win32/direct3d11/overviews-direct3d-11-devices-downlevel-intro#overview)  of the resource from the manifest's `Resources\Resource` field. | An optional string that can have one of the following values: *dx9*, *dx10*, *dx11*, or *dx12*. | No |  |
 

--- a/winrt-related-src/schemas/appxpackage/uapmanifestschema/element-uap5-outofprocessserver.md
+++ b/winrt-related-src/schemas/appxpackage/uapmanifestschema/element-uap5-outofprocessserver.md
@@ -72,4 +72,4 @@ Declares a package extension point of type *windows.activatableClass.outOfProces
 
 ## Remarks
 
-This element is similar to the [OutOfProcessServer](element-outOfProcessServer.md) element in Package/Extensions. Activate As Package behavior is implied by using this element in the Application/Extensions level of the manifest, indicating that the server token doesn't vary based on the activating process's token. In this context, the application identity claim matches the identity of the application it's contained in.
+This element is similar to the [OutOfProcessServer](element-f-outofprocessserver.md) element in Package/Extensions. Activate As Package behavior is implied by using this element in the Application/Extensions level of the manifest, indicating that the server token doesn't vary based on the activating process's token. In this context, the application identity claim matches the identity of the application it's contained in.

--- a/winrt-related-src/schemas/appxpackage/uapmanifestschema/localizable-manifest-items-win10.md
+++ b/winrt-related-src/schemas/appxpackage/uapmanifestschema/localizable-manifest-items-win10.md
@@ -20,7 +20,7 @@ You can localize these strings in the manifest:
 
 -   **[Application/uap3:VisualElements/@DisplayName](element-uap3-visualelements.md)**
 -   **[Application/uap3:VisualElements/@Description](element-uap3-visualelements.md)**
--   **[com:ComInterface/com:ProxyStub/@DisplayName](element-com-package-proxystub.md)**
+-   **[com:ComInterface/com:ProxyStub/@DisplayName](element-com-proxystub.md)**
 -   **[com:ComServer/com:ExeServer/@DisplayName](element-com-exeserver.md)**
 -   **[com:ComServer/com:SurrogateServer/@DisplayName](element-com-surrogateserver.md)**
 -   **[com:ComServer/com:TreatAsClass/@DisplayName](element-com-treatasclass.md)**

--- a/winrt-related-src/schemas/bundlemanifestschema/element-dependencies.md
+++ b/winrt-related-src/schemas/bundlemanifestschema/element-dependencies.md
@@ -70,7 +70,7 @@ None.
 <tbody>
 <tr class="odd">
 <td><a href="element-targetdevicefamily.md">TargetDeviceFamily</a> </td>
-<td><p>Identifies the device family that a package targets. For more info about device families, see [Programming with extension SDKs](../../../extension-sdks/device-families-overview.md).</p></td>
+<td><p>Identifies the device family that a package targets. For more info about device families, see [Programming with extension SDKs](../../extension-sdks/device-families-overview.md).</p></td>
 </tr>
 </tbody>
 </table>

--- a/winrt-related-src/schemas/bundlemanifestschema/element-optionalbundle-resource.md
+++ b/winrt-related-src/schemas/bundlemanifestschema/element-optionalbundle-resource.md
@@ -52,7 +52,7 @@ Declares language, resolution scale, and DirectX feature level for a resource in
 | Attribute | Description | Data type | Required |
 |-----------|-------------|-----------|----------|
 | DXFeatureLevel | The [DirectX feature level](/windows/win32/direct3d11/overviews-direct3d-11-devices-downlevel-intro#overview) for the resource. | One of the following: "dx9", "dx10", "dx11" | No |
-| Language | The language for the resource. The syntax of this attribute is defined by the IETF's [BCP47: Tags for Identifying Languages](https://www.rfc-editor.org/rfc/bcp/bcp47.txt). | language | No |
+| Language | The language for the resource. The syntax of this attribute is defined by the IETF's [BCP47: Tags for Identifying Languages](https://www.rfc-editor.org/info/bcp47). | language | No |
 | Scale | The resolution scale for the resource. | One of the following: "100", "120", "125", "140", "150", "160", "180", "200", "220", "225", "240", "250", "300", "400", "500" | No |
 
 ## Remarks

--- a/winrt-related-src/schemas/bundlemanifestschema/element-resource.md
+++ b/winrt-related-src/schemas/bundlemanifestschema/element-resource.md
@@ -87,7 +87,7 @@ Declares language, resolution scale, and DirectX feature level for a resource in
 </tr>
 <tr class="even">
 <td><strong>Language</strong></td>
-<td><p>The language for the resource. The syntax of this attribute is defined by the IETF's <a href="https://www.rfc-editor.org/rfc/bcp/bcp47.txt">BCP47: Tags for Identifying Languages</a> .</p></td>
+<td><p>The language for the resource. The syntax of this attribute is defined by the IETF's <a href="https://www.rfc-editor.org/info/bcp47">BCP47: Tags for Identifying Languages</a> .</p></td>
 <td>language</td>
 <td>No</td>
 <td></td>

--- a/winrt-related-src/schemas/storemanifest/storemanifestschema2015/element-dependencies.md
+++ b/winrt-related-src/schemas/storemanifest/storemanifestschema2015/element-dependencies.md
@@ -86,7 +86,7 @@ None.
 <td><a href="element-targetdevicefamily.md">TargetDeviceFamily</a> </td>
 <td><p>Identifies the device family that your package targets.</p>
 <div class="alert">
-<strong>Important</strong>  In most cases, you should simply specify your device families in the [<strong>TargetDeviceFamily</strong>](../../appxpackage/uapmanifestschema/element-targetdevicefamily.md) element of your AppxManifest. Values here should only be used if you need to override that info (using a subset of the values provided there).
+<strong>Important</strong>  In most cases, you should simply specify your device families in the [<strong>TargetDeviceFamily</strong>](../../appxpackage/uapmanifestschema/element-f-targetdevicefamily.md) element of your AppxManifest. Values here should only be used if you need to override that info (using a subset of the values provided there).
 </div>
 <div>
  

--- a/winrt-related-src/schemas/storemanifest/storemanifestschema2015/element-targetdevicefamily.md
+++ b/winrt-related-src/schemas/storemanifest/storemanifestschema2015/element-targetdevicefamily.md
@@ -17,7 +17,7 @@ ms.date: 04/05/2017
 
 Identifies the device family that your package targets.
 
-**Important**  In most cases, you should simply specify your device families in the [**TargetDeviceFamily**](../../appxpackage/uapmanifestschema/element-targetdevicefamily.md) element of your AppxManifest. Values here should only be used if you need to override that info (using a subset of the values provided there).
+**Important**  In most cases, you should simply specify your device families in the [**TargetDeviceFamily**](../../appxpackage/uapmanifestschema/element-f-targetdevicefamily.md) element of your AppxManifest. Values here should only be used if you need to override that info (using a subset of the values provided there).
 
  
 

--- a/winrt-related-src/schemas/storemanifest/storemanifestschema2015/schema-root.md
+++ b/winrt-related-src/schemas/storemanifest/storemanifestschema2015/schema-root.md
@@ -77,7 +77,7 @@ The following table lists all of the elements in this schema, sorted alphabetica
 <td><a href="element-targetdevicefamily.md">TargetDeviceFamily</a> </td>
 <td><p>Identifies the device family that your package targets.</p>
 <div class="alert">
-<strong>Important</strong>  In most cases, you should simply specify your device families in the [<strong>TargetDeviceFamily</strong>](../../appxpackage/uapmanifestschema/element-targetdevicefamily.md) element of your AppxManifest. Values here should only be used if you need to override that info (using a subset of the values provided there).
+<strong>Important</strong>  In most cases, you should simply specify your device families in the [<strong>TargetDeviceFamily</strong>](../../appxpackage/uapmanifestschema/element-f-targetdevicefamily.md) element of your AppxManifest. Values here should only be used if you need to override that info (using a subset of the values provided there).
 </div>
 <div>
  


### PR DESCRIPTION
## Summary

- repair 13 unresolved relative links to existing schema/reference topics
- replace five retired RFC Editor BCP 47 URLs with the current canonical page

## Link-health audit

- 10,136 relative link occurrences checked
- 3,839 unique HTTP targets checked with bounded concurrency
- no cross-repo Learn 404s found
- one ISO URL returned HTTP 403 to automated checks and was left unchanged for manual review
- three known-slow IEEE targets were skipped

## Validation

- unresolved relative links after fixes: 0
- RFC Editor replacement: HTTP 200
- `git diff --check` passes